### PR TITLE
Define gflag/flag/option as synonyms in searches.

### DIFF
--- a/yb-docs.json
+++ b/yb-docs.json
@@ -29,7 +29,14 @@
   },
     "custom_settings": {
       "advancedSyntax": true,
-      "separatorsToIndex": "_"
+      "separatorsToIndex": "_",
+      "synonyms": [
+        [
+          "gflag",
+          "flag",
+          "option"
+        ]
+      ]
   },
   "selectors_exclude": [],
   "nb_hits": 21609


### PR DESCRIPTION
When a user searches for "flag" or "flag", results for "option" will also be returned.